### PR TITLE
Adding vr_movespeed CVar

### DIFF
--- a/neo/framework/UsercmdGen.cpp
+++ b/neo/framework/UsercmdGen.cpp
@@ -1136,6 +1136,7 @@ void idUsercmdGenLocal::VRControlMove()
 
 		if ( move )
 		{
+			const float moveSpeed = vr_moveSpeed.GetFloat();
 			if( vr_forwardOnly.GetBool() )
 			{
 				cmd.forwardmove = idMath::ClampChar( cmd.forwardmove + KEY_MOVESPEED );
@@ -1152,10 +1153,10 @@ void idUsercmdGenLocal::VRControlMove()
 					len += dif * response;
 					axis *= len;
 				}
-				cmd.forwardmove = idMath::ClampChar( cmd.forwardmove + KEY_MOVESPEED * axis.y );
+				cmd.forwardmove = idMath::ClampChar( cmd.forwardmove + KEY_MOVESPEED * axis.y * moveSpeed );
 				if( vr_strafing.GetBool() )
 				{
-					cmd.rightmove = idMath::ClampChar( cmd.rightmove + KEY_MOVESPEED * axis.x );
+					cmd.rightmove = idMath::ClampChar( cmd.rightmove + KEY_MOVESPEED * axis.x * moveSpeed );
 				}
 			}
 		}

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -296,7 +296,8 @@ idCVar vr_forwardOnly( "vr_forwardOnly", "0", CVAR_ARCHIVE | CVAR_BOOL, "left to
 idCVar vr_maxRadius( "vr_maxRadius", "0.9", CVAR_ARCHIVE | CVAR_FLOAT, "smaller values make it easier to hit max movement speed" );
 idCVar vr_turning( "vr_turning", "0", CVAR_ARCHIVE | CVAR_BOOL, "0 no turning | 1 touch turning" );
 idCVar vr_responseCurve( "vr_responseCurve", "0", CVAR_ARCHIVE | CVAR_FLOAT, "interpoloate between linear and square curves, -1 for inverse square" );
-idCVar vr_moveMode( "vr_moveMode", "0", CVAR_ARCHIVE | CVAR_INTEGER, "	0 touch walk | 1 touch walk & hold run | 2 touch walk & click run | 3 click walk | 4 click walk & hold run | 5 click walk & double click run | 6 hold walk" );
+idCVar vr_moveMode("vr_moveMode", "0", CVAR_ARCHIVE | CVAR_INTEGER, "	0 touch walk | 1 touch walk & hold run | 2 touch walk & click run | 3 click walk | 4 click walk & hold run | 5 click walk & double click run | 6 hold walk");
+idCVar vr_moveSpeed("vr_moveSpeed", "1", CVAR_ARCHIVE | CVAR_FLOAT, "Touchpad player movement speed is multiplied by this value. Set to 1 for normal speed, or between 0 and 1 for slower movement.");
 
 const char* fileExten[3] = { "tga", "png", "jpg" };
 const char* envDirection[6] = { "_px", "_nx", "_py", "_ny", "_pz", "_nz" };

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -1146,6 +1146,7 @@ extern idCVar vr_forwardOnly;
 extern idCVar vr_turning;
 extern idCVar vr_responseCurve;
 extern idCVar vr_moveMode;
+extern idCVar vr_moveSpeed;
 
 /*
 ====================================================================


### PR DESCRIPTION
This adds a multiplier value for touchpad movement speed, allowing users to slow down touchpad movement speed with a cvar for those that find slower movement easier on the stomach. Parts of the game that require full speed movement can use the normal move speed. Default is 1, which is normal move speed.