### PR TITLE
Option to make movement based on HMD direction

### DIFF
--- a/neo/d3xp/Player.cpp
+++ b/neo/d3xp/Player.cpp
@@ -7127,6 +7127,8 @@ void idPlayer::SetViewAngles( const idAngles& angles )
 idPlayer::UpdateViewAngles
 ================
 */
+idCVar vr_moveLook("vr_moveLook", "0", CVAR_ARCHIVE | CVAR_BOOL, "Makes movement based on head direction instead of controller");
+
 void idPlayer::UpdateViewAngles()
 {
 	int i;
@@ -7238,7 +7240,8 @@ void idPlayer::UpdateViewAngles()
 			vrFaceForward = VR_GetSeatedAxisInverse();
 			hadBodyYaw = false;
 		}
-		else if (usercmd.vrHasLeftController)
+		//this is where forward is based on left controller or head while standing
+		else if (usercmd.vrHasLeftController && !vr_moveLook.GetBool())
 		{
 			float yaw = usercmd.vrLeftControllerAxis.ToAngles().yaw;
 			vrFaceForward = idAngles(0, -yaw, 0).ToMat3();


### PR DESCRIPTION
Added vr_moveLook which when true makes movement directions relative to the direction the player is looking instead of the direction of the left controller. So move where you look for a more traditional FPS feel while using Vive motion controllers.