### PR TITLE
Introduced vr_comfortMode 

### DIFF
--- a/neo/d3xp/Player.cpp
+++ b/neo/d3xp/Player.cpp
@@ -8579,6 +8579,38 @@ void idPlayer::Move()
 	
 	BobCycle( pushVelocity );
 	CrashLand( oldOrigin, oldVelocity );
+
+	// Handling vr_comfortMode
+	const int comfortMode = vr_comfortMode.GetInteger();
+	//"	0 off | 1 tunnel | 2 slow mo | 3 tunnel + slow mo"
+	if (comfortMode == 0) 
+	{
+		return;
+	}
+
+	float speed = physicsObj.GetLinearVelocity().LengthFast();
+	if ((comfortMode == 1) || (comfortMode == 3)) 
+	{
+		if (speed == 0)
+		{
+			this->playerView.EnableVrComfortVision(false);
+		}
+		else
+		{
+			this->playerView.EnableVrComfortVision(true);
+		}
+	}
+
+	if ((comfortMode == 2) || (comfortMode == 3)) 
+	{
+		extern idCVar timescale;
+		float speedFactor = ((pm_runspeed.GetFloat() - speed) / pm_runspeed.GetFloat());
+		if (speedFactor < 0)
+		{
+			speedFactor = 0;
+		}
+		timescale.SetFloat(0.5 + 0.5*speedFactor);
+	}
 }
 
 /*

--- a/neo/d3xp/PlayerView.cpp
+++ b/neo/d3xp/PlayerView.cpp
@@ -51,6 +51,7 @@ idPlayerView::idPlayerView()
 	bloodSprayMaterial = declManager->FindMaterial( "textures/decals/bloodspray" );
 	bfgMaterial = declManager->FindMaterial( "textures/decals/bfgvision" );
 	bfgVision = false;
+	vrComfortVision = false;
 	dvFinishTime = 0;
 	kickFinishTime = 0;
 	kickAngles.Zero();
@@ -577,7 +578,55 @@ void idPlayerView::SingleView( const renderView_t* view, idMenuHandler_HUD* hudM
 			renderSystem->SetColor4( 1.0f, 1.0f, 1.0f, 1.0f );
 			renderSystem->DrawStretchPic( offset - extend, 0.0f, renderSystem->GetVirtualWidth() + extend * 2, renderSystem->GetVirtualHeight(), 0.0f, 0.0f, 1.0f, 1.0f, bfgMaterial );
 		}
-		
+
+		if (vrComfortVision) {
+			tr.guiModel->SetMode(GUIMODE_FULLSCREEN);
+			float extend = -0.5f * glConfig.openVRScreenSeparation * renderSystem->GetVirtualWidth();
+			float offset = -extend * view->viewEyeBuffer;
+
+			renderSystem->SetColor4(0, 0, 0, 255);
+
+			int width = renderSystem->GetVirtualWidth();
+			int height = renderSystem->GetVirtualHeight();
+			int blockwidth = width * 4;
+			int blockheight = height * 4;
+
+			renderSystem->DrawStretchPic(
+				offset - extend - blockwidth, -blockheight,
+				blockwidth + extend * 2, blockheight,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+			renderSystem->DrawStretchPic(
+				offset - extend, -blockheight,
+				width, blockheight + height / 3.0,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+			renderSystem->DrawStretchPic(
+				offset - extend + width, -blockheight,
+				blockwidth + extend * 2, blockheight,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+
+			renderSystem->DrawStretchPic(
+				offset - extend - blockwidth, 0,
+				blockwidth + extend * 2 + width / 3.0, height,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+			renderSystem->DrawStretchPic(
+				offset - extend + width - width / 3.0, 0,
+				blockwidth + extend * 2 + width / 3.0, height,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+
+			renderSystem->DrawStretchPic(
+				offset - extend - blockwidth, height,
+				blockwidth + extend * 2, blockheight,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+			renderSystem->DrawStretchPic(
+				offset - extend, height - height / 3.0,
+				width + extend * 2, blockheight + height / 3.0,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+			renderSystem->DrawStretchPic(
+				offset - extend + width, height,
+				blockwidth + extend * 2, blockheight,
+				0.0f, 0.0f, 1.0f, 1.0f, declManager->FindMaterial("_white"));
+			renderSystem->SetGLState(0); // JACK: unsure if this is required?
+		}
 	}
 	
 	// test a single material drawn over everything

--- a/neo/d3xp/PlayerView.h
+++ b/neo/d3xp/PlayerView.h
@@ -441,7 +441,13 @@ public:
 	{
 		bfgVision = b;
 	};
-	
+
+	// for VR comfort vision
+	void				EnableVrComfortVision(bool b)
+	{
+		vrComfortVision = b;
+	};
+
 private:
 	void				SingleView( const renderView_t* view, idMenuHandler_HUD* hudManager );
 	void				ScreenFade();
@@ -456,7 +462,8 @@ public:
 	int					kickFinishTime;		// view kick will be stopped at this time
 	idAngles			kickAngles;
 	
-	bool				bfgVision;			//
+	bool				bfgVision;			
+	bool				vrComfortVision;	//  "tunnel" to improve vrComfort
 	
 	const idMaterial* 	tunnelMaterial;		// health tunnel vision
 	const idMaterial* 	armorMaterial;		// armor damage view effect

--- a/neo/renderer/RenderSystem_init.cpp
+++ b/neo/renderer/RenderSystem_init.cpp
@@ -298,6 +298,7 @@ idCVar vr_maxRadius( "vr_maxRadius", "0.9", CVAR_ARCHIVE | CVAR_FLOAT, "smaller 
 idCVar vr_responseCurve( "vr_responseCurve", "0", CVAR_ARCHIVE | CVAR_FLOAT, "interpoloate between linear and square curves, -1 for inverse square" );
 idCVar vr_moveMode("vr_moveMode", "8", CVAR_ARCHIVE | CVAR_INTEGER, "	0 touch walk | 1 touch walk & hold run | 2 touch walk & click run | 3 click walk | 4 click walk & hold run | 5 click walk & double click run | 6 hold walk");
 idCVar vr_moveSpeed("vr_moveSpeed", "0.5", CVAR_ARCHIVE | CVAR_FLOAT, "Touchpad player movement speed is multiplied by this value. Set to 1 for normal speed, or between 0 and 1 for slower movement.");
+idCVar vr_comfortMode("vr_comfortMode", "3", CVAR_ARCHIVE | CVAR_INTEGER, "	0 off | 1 tunnel | 2 slow mo | 3 tunnel + slow mo");
 
 const char* fileExten[3] = { "tga", "png", "jpg" };
 const char* envDirection[6] = { "_px", "_nx", "_py", "_ny", "_pz", "_nz" };

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -1147,6 +1147,8 @@ extern idCVar vr_relativeAxis;
 extern idCVar vr_responseCurve;
 extern idCVar vr_moveMode;
 extern idCVar vr_moveSpeed;
+extern idCVar vr_comfortMode;
+
 
 /*
 ====================================================================


### PR DESCRIPTION
Added the vr_comfortMode variable 
0 - turn off
1 - tunnel
2 - slow motion
3 - tunnel + slow motion

Tunnel will minimizes your peripheral vision in a similar manner to Google Earth VR.
Slow motion reduces the perceived walking/running speed by dropping the timescale, instead of pm_walkspeed and pm_runspeed. So game physics are less affected.

The comfort mode in action can be viewed at https://youtu.be/9jBomLN_nrk